### PR TITLE
Add support for injecting a callable resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ If you want to change this behaviour, use a container implementing the [PSR-11 s
 
 The dispatcher instance to use.
 
-#### `resolver(Psr\Container\ContainerInterface $resolver)`
+#### `container(Psr\Container\ContainerInterface $container)`
 
 To use a container implementing [PSR-11 interface](https://github.com/php-fig/container) to resolve the route handlers.
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ If you want to change this behaviour, use a container implementing the [PSR-11 s
 
 The dispatcher instance to use.
 
+#### `resolver(Middlewares\Utils\CallableResolver\CallableResolverInterface $resolver)`
+
+The resolver implementing [CallableResolverInterface]() to resolve the route handlers.
+
 #### `container(Psr\Container\ContainerInterface $container)`
 
 To use a container implementing [PSR-11 interface](https://github.com/php-fig/container) to resolve the route handlers.

--- a/src/FastRoute.php
+++ b/src/FastRoute.php
@@ -42,13 +42,13 @@ class FastRoute implements MiddlewareInterface
     }
 
     /**
-     * Set the resolver used to create the controllers.
+     * Set the container used to create the controllers.
      *
      * @param ContainerInterface $container
      *
      * @return self
      */
-    public function resolver(ContainerInterface $container)
+    public function container(ContainerInterface $container)
     {
         $this->resolver = new ContainerResolver($container);
 

--- a/src/FastRoute.php
+++ b/src/FastRoute.php
@@ -42,6 +42,20 @@ class FastRoute implements MiddlewareInterface
     }
 
     /**
+     * Set the resolver used to create the controllers.
+     *
+     * @param CallableResolverInterface $resolver
+     *
+     * @return self
+     */
+    public function resolver(CallableResolverInterface $resolver)
+    {
+        $this->resolver = $resolver;
+
+        return $this;
+    }
+
+    /**
      * Set the container used to create the controllers.
      *
      * @param ContainerInterface $container

--- a/tests/FastRouteTest.php
+++ b/tests/FastRouteTest.php
@@ -77,7 +77,7 @@ class FastRouteTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(405, $response->getStatusCode());
     }
 
-    public function testFastRouteContainerResolve()
+    public function testFastRouteContainerResolver()
     {
         $dispatcher = \FastRoute\simpleDispatcher(function (\FastRoute\RouteCollector $r) {
             $r->addRoute('POST', '/user/{name}/{id:[0-9]+}', 'controller');
@@ -85,9 +85,9 @@ class FastRouteTest extends \PHPUnit_Framework_TestCase
 
         $request = Factory::createServerRequest([], 'POST', 'http://domain.com/user/oscarotero/35');
 
-        /** @var ContainerInterface|ObjectProphecy $resolver */
-        $resolver = $this->prophesize(ContainerInterface::class);
-        $resolver->get('controller')->willReturn(function ($request) {
+        /** @var ContainerInterface|ObjectProphecy $container */
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->get('controller')->willReturn(function ($request) {
             return sprintf(
                 'Hello %s (%s)',
                 $request->getAttribute('name'),
@@ -96,7 +96,7 @@ class FastRouteTest extends \PHPUnit_Framework_TestCase
         });
 
         $middleware = new FastRoute($dispatcher);
-        $middleware->resolver($resolver->reveal());
+        $middleware->container($container->reveal());
 
         $response = Dispatcher::run([
             $middleware,


### PR DESCRIPTION
Right now the only option for people that do not use PSR-11 containers
is to make all of their routes into closures. By allowing direct
injection of a callable resolver, anyone will be able to write a
resolver that suites their application.

This **breaks backwards compatibility** by replacing the previous resolver and moving it to `container()`.