### PR TITLE
Send Allow header when method is not allowed

### DIFF
--- a/src/FastRoute.php
+++ b/src/FastRoute.php
@@ -98,7 +98,7 @@ class FastRoute implements MiddlewareInterface
         }
 
         if ($route[0] === Dispatcher::METHOD_NOT_ALLOWED) {
-            return Factory::createResponse(405);
+            return Factory::createResponse(405)->withHeader('Allow', implode(', ', $route[1]));
         }
 
         foreach ($route[2] as $name => $value) {

--- a/tests/FastRouteTest.php
+++ b/tests/FastRouteTest.php
@@ -67,6 +67,14 @@ class FastRouteTest extends \PHPUnit_Framework_TestCase
                     $request->getAttribute('id')
                 );
             });
+
+            $r->addRoute('PUT', '/user/{name}/{id:[0-9]+}', function ($request) {
+                return sprintf(
+                    'Hello %s (%s)',
+                    $request->getAttribute('name'),
+                    $request->getAttribute('id')
+                );
+            });
         });
 
         $request = Factory::createServerRequest([], 'GET', 'http://domain.com/user/oscarotero/35');
@@ -77,6 +85,7 @@ class FastRouteTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Psr\\Http\\Message\\ResponseInterface', $response);
         $this->assertEquals(405, $response->getStatusCode());
+        $this->assertEquals('POST, PUT', $response->getHeaderLine('Allow'));
     }
 
     public function testFastRouteResolver()


### PR DESCRIPTION
With HTTP status 405 the response **must** include an `Allow` header
that declares the allowed methods for the request.

From [the docs](https://github.com/nikic/FastRoute#dispatching-a-uri):

> **NOTE:** The HTTP specification requires that a `405 Method Not Allowed` response include the
`Allow:` header to detail available methods for the requested resource. Applications using FastRoute should use the second array element to add this header when relaying a 405 response.