### PR TITLE
Only request handler discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.7.0] - 2017-04-19
+
+### Changed
+
+* Handlers are no longer executed, only passed as attribute references.
+
 ## [0.6.0] - 2017-04-13
 
 ### Changed
@@ -51,6 +57,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 First version
 
+[0.7.0]: https://github.com/middlewares/fast-route/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/middlewares/fast-route/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/middlewares/fast-route/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/middlewares/fast-route/compare/v0.3.0...v0.4.0

--- a/README.md
+++ b/README.md
@@ -7,14 +7,13 @@
 [![Total Downloads][ico-downloads]][link-downloads]
 [![SensioLabs Insight][ico-sensiolabs]][link-sensiolabs]
 
-Middleware to use [FastRoute](https://github.com/nikic/FastRoute).
+Middleware to use [FastRoute](https://github.com/nikic/FastRoute) for handler discovery.
 
 ## Requirements
 
 * PHP >= 5.6
 * A [PSR-7](https://packagist.org/providers/psr/http-message-implementation) http mesage implementation ([Diactoros](https://github.com/zendframework/zend-diactoros), [Guzzle](https://github.com/guzzle/psr7), [Slim](https://github.com/slimphp/Slim), etc...)
 * A [PSR-15 middleware dispatcher](https://github.com/middlewares/awesome-psr15-middlewares#dispatcher)
-* Optionally, a [PSR-11](https://github.com/php-fig/container) container to resolve the route handlers
 
 ## Installation
 
@@ -23,6 +22,8 @@ This package is installable and autoloadable via Composer as [middlewares/fast-r
 ```sh
 composer require middlewares/fast-route
 ```
+
+You may also want to install [middlewares/request-handler](https://packagist.org/packages/middlewares/request-handler).
 
 ## Example
 
@@ -45,53 +46,24 @@ $dispatcher = FastRoute\simpleDispatcher(function (FastRoute\RouteCollector $r) 
 });
 
 $dispatcher = new Dispatcher([
-    new Middlewares\FastRoute($dispatcher)
+    new Middlewares\FastRoute($dispatcher),
+    // ...
 ]);
 
 $response = $dispatcher->dispatch(new ServerRequest('/hello/world'));
 ```
 
-**fastRoute** allows to define anything as the router handler (a closure, callback, action object, controller class, etc). By default, it's interpreted in the following way:
-
-* If it's a string similar to `Namespace\Class::method`, and the method is not static, create a instance of `Namespace\Class` and call the method.
-* If the string is the name of a existing class (like: `Namespace\Class`) and contains the method `__invoke`, create a instance and execute that method.
-* Otherwise, treat it as a callable.
-
-If you want to change this behaviour, use a container implementing the [PSR-11 spec](https://github.com/php-fig/container) to return the route callable.
+**FastRoute** allows anything to be defined as the router handler (a closure, callback, action object, controller class, etc). The middleware will store this handler in a request attribute.
 
 ## Options
 
-#### `__construct(FastRoute\Dispatcher $dispatcher)`
+### `__construct(FastRoute\Dispatcher $dispatcher)`
 
 The dispatcher instance to use.
 
-#### `resolver(Middlewares\Utils\CallableResolver\CallableResolverInterface $resolver)`
+### `attribute(string $attribute)`
 
-The resolver implementing [CallableResolverInterface]() to resolve the route handlers.
-
-#### `container(Psr\Container\ContainerInterface $container)`
-
-To use a container implementing [PSR-11 interface](https://github.com/php-fig/container) to resolve the route handlers.
-
-#### `arguments(...$args)`
-
-Extra arguments to pass to the controller. This is useful to inject, for example a service container:
-
-```php
-$dispatcher = FastRoute\simpleDispatcher(function (FastRoute\RouteCollector $r) {
-    $r->addRoute('GET', '/posts/{id}', function ($request, $app) {
-        $id = $request->getAttribute('id');
-        $post = $app->get('database')->select($id);
-        
-        return $app->get('templates')->render($post);
-    });
-});
-
-$dispatcher = new Dispatcher([
-    (new Middlewares\FastRoute($dispatcher))
-        ->arguments($app)
-]);
-```
+The attribute name used to store the handler in the server request. The default attribute name is `request-handler`.
 
 ---
 

--- a/src/FastRoute.php
+++ b/src/FastRoute.php
@@ -3,13 +3,8 @@
 namespace Middlewares;
 
 use Middlewares\Utils\Factory;
-use Middlewares\Utils\CallableHandler;
-use Middlewares\Utils\CallableResolver\CallableResolverInterface;
-use Middlewares\Utils\CallableResolver\ContainerResolver;
-use Middlewares\Utils\CallableResolver\ReflectionResolver;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Psr\Container\ContainerInterface;
 use Interop\Http\ServerMiddleware\MiddlewareInterface;
 use Interop\Http\ServerMiddleware\DelegateInterface;
 use FastRoute\Dispatcher;
@@ -22,14 +17,9 @@ class FastRoute implements MiddlewareInterface
     private $router;
 
     /**
-     * @var array Extra arguments passed to the controller
+     * @var string Attribute name for handler reference
      */
-    private $arguments = [];
-
-    /**
-     * @var CallableResolverInterface Used to resolve the controllers
-     */
-    private $resolver;
+    private $attribute = 'request-handler';
 
     /**
      * Set the Dispatcher instance.
@@ -42,39 +32,15 @@ class FastRoute implements MiddlewareInterface
     }
 
     /**
-     * Set the resolver used to create the controllers.
+     * Set the attribute name to store handler reference.
      *
-     * @param CallableResolverInterface $resolver
-     *
-     * @return self
-     */
-    public function resolver(CallableResolverInterface $resolver)
-    {
-        $this->resolver = $resolver;
-
-        return $this;
-    }
-
-    /**
-     * Set the container used to create the controllers.
-     *
-     * @param ContainerInterface $container
+     * @param string $attribute
      *
      * @return self
      */
-    public function container(ContainerInterface $container)
+    public function attribute($attribute)
     {
-        return $this->resolver(new ContainerResolver($container));
-    }
-
-    /**
-     * Extra arguments passed to the callable.
-     *
-     * @return self
-     */
-    public function arguments()
-    {
-        $this->arguments = func_get_args();
+        $this->attribute = $attribute;
 
         return $this;
     }
@@ -103,24 +69,21 @@ class FastRoute implements MiddlewareInterface
             $request = $request->withAttribute($name, $value);
         }
 
-        $arguments = array_merge([$request], $this->arguments);
+        $request = $this->setHandler($request, $route[1]);
 
-        $callable = $this->getResolver()->resolve($route[1], $arguments);
-
-        return CallableHandler::execute($callable, $arguments);
+        return $delegate->process($request);
     }
 
     /**
-     * Return the resolver used for the controllers
+     * Set the handler reference on the request.
      *
-     * @return CallableResolverInterface
+     * @param ServerRequestInterface $request
+     * @param callable|string|array  $handler
+     *
+     * @return ServerRequestInterface
      */
-    private function getResolver()
+    protected function setHandler(ServerRequestInterface $request, $handler)
     {
-        if (!isset($this->resolver)) {
-            $this->resolver = new ReflectionResolver();
-        }
-
-        return $this->resolver;
+        return $request->withAttribute($this->attribute, $handler);
     }
 }

--- a/tests/FastRouteTest.php
+++ b/tests/FastRouteTest.php
@@ -2,51 +2,22 @@
 
 namespace Middlewares\Tests;
 
-use Psr\Container\ContainerInterface;
+use FastRoute\RouteCollector;
 use Middlewares\FastRoute;
-use Middlewares\Utils\CallableResolver\CallableResolverInterface;
 use Middlewares\Utils\Dispatcher;
 use Middlewares\Utils\Factory;
-use Prophecy\Argument;
-use Prophecy\Prophecy\ObjectProphecy;
-use Psr\Http\Message\ServerRequestInterface;
+
+use function FastRoute\simpleDispatcher;
 
 class FastRouteTest extends \PHPUnit_Framework_TestCase
 {
-    public function testFastRouteOK()
-    {
-        $dispatcher = \FastRoute\simpleDispatcher(function (\FastRoute\RouteCollector $r) {
-            $r->addRoute('GET', '/user/{name}/{id:[0-9]+}', function ($request) {
-                echo sprintf(
-                    'Hello %s (%s)',
-                    $request->getAttribute('name'),
-                    $request->getAttribute('id')
-                );
-            });
-        });
-
-        $request = Factory::createServerRequest([], 'GET', 'http://domain.com/user/oscarotero/35');
-
-        $response = Dispatcher::run([
-            new FastRoute($dispatcher),
-        ], $request);
-
-        $this->assertEquals('Hello oscarotero (35)', (string) $response->getBody());
-    }
-
     public function testFastRouteNotFound()
     {
-        $dispatcher = \FastRoute\simpleDispatcher(function (\FastRoute\RouteCollector $r) {
-            $r->addRoute('GET', '/user/{name}/{id:[0-9]+}', function ($request) {
-                echo sprintf(
-                    'Hello %s (%s)',
-                    $request->getAttribute('name'),
-                    $request->getAttribute('id')
-                );
-            });
+        $dispatcher = simpleDispatcher(function (\FastRoute\RouteCollector $r) {
+            $r->get('/users', 'listUsers');
         });
 
-        $request = Factory::createServerRequest([], 'GET', 'http://domain.com/username/oscarotero/35');
+        $request = Factory::createServerRequest([], 'GET', '/posts');
 
         $response = Dispatcher::run([
             new FastRoute($dispatcher),
@@ -57,87 +28,54 @@ class FastRouteTest extends \PHPUnit_Framework_TestCase
 
     public function testFastRouteNotAllowed()
     {
-        $dispatcher = \FastRoute\simpleDispatcher(function (\FastRoute\RouteCollector $r) {
-            $r->addRoute('POST', '/user/{name}/{id:[0-9]+}', function ($request) {
-                return sprintf(
-                    'Hello %s (%s)',
-                    $request->getAttribute('name'),
-                    $request->getAttribute('id')
-                );
-            });
-
-            $r->addRoute('PUT', '/user/{name}/{id:[0-9]+}', function ($request) {
-                return sprintf(
-                    'Hello %s (%s)',
-                    $request->getAttribute('name'),
-                    $request->getAttribute('id')
-                );
-            });
+        $dispatcher = simpleDispatcher(function (\FastRoute\RouteCollector $r) {
+            $r->get('/users', 'listUsers');
+            $r->post('/users', 'createUser');
         });
 
-        $request = Factory::createServerRequest([], 'GET', 'http://domain.com/user/oscarotero/35');
+        $request = Factory::createServerRequest([], 'DELETE', '/users');
 
         $response = Dispatcher::run([
             new FastRoute($dispatcher),
         ], $request);
 
         $this->assertEquals(405, $response->getStatusCode());
-        $this->assertEquals('POST, PUT', $response->getHeaderLine('Allow'));
+        $this->assertEquals('GET, POST', $response->getHeaderLine('Allow'));
     }
 
-    public function testFastRouteResolver()
+    public function testFastRouteOK()
     {
-        $dispatcher = \FastRoute\simpleDispatcher(function (\FastRoute\RouteCollector $r) {
-            $r->addRoute('POST', '/user/{name}/{id:[0-9]+}', 'controller');
+        $dispatcher = simpleDispatcher(function (\FastRoute\RouteCollector $r) {
+            $r->get('/users', 'listUsers');
         });
 
-        $request = Factory::createServerRequest([], 'POST', 'http://domain.com/user/oscarotero/35');
-
-        /** @var CallableResolverInterface|ObjectProphecy $resolver */
-        $resolver = $this->prophesize(CallableResolverInterface::class);
-        $resolver->resolve('controller', Argument::cetera())->willReturn(function ($request) {
-            return sprintf(
-                'Hello %s (%s)',
-                $request->getAttribute('name'),
-                $request->getAttribute('id')
-            );
-        });
-
-        $middleware = new FastRoute($dispatcher);
-        $middleware->resolver($resolver->reveal());
+        $request = Factory::createServerRequest([], 'GET', '/users');
 
         $response = Dispatcher::run([
-            $middleware,
+            new FastRoute($dispatcher),
+            function ($request) {
+                echo $request->getAttribute('request-handler');
+            }
         ], $request);
 
-        $this->assertEquals('Hello oscarotero (35)', (string) $response->getBody());
+        $this->assertEquals('listUsers', (string) $response->getBody());
     }
 
-    public function testFastRouteContainerResolver()
+    public function testFastRouteCustomAttribute()
     {
-        $dispatcher = \FastRoute\simpleDispatcher(function (\FastRoute\RouteCollector $r) {
-            $r->addRoute('POST', '/user/{name}/{id:[0-9]+}', 'controller');
+        $dispatcher = simpleDispatcher(function (\FastRoute\RouteCollector $r) {
+            $r->get('/users', 'listUsers');
         });
 
-        $request = Factory::createServerRequest([], 'POST', 'http://domain.com/user/oscarotero/35');
-
-        /** @var ContainerInterface|ObjectProphecy $container */
-        $container = $this->prophesize(ContainerInterface::class);
-        $container->get('controller')->willReturn(function ($request) {
-            return sprintf(
-                'Hello %s (%s)',
-                $request->getAttribute('name'),
-                $request->getAttribute('id')
-            );
-        });
-
-        $middleware = new FastRoute($dispatcher);
-        $middleware->container($container->reveal());
+        $request = Factory::createServerRequest([], 'GET', '/users');
 
         $response = Dispatcher::run([
-            $middleware,
+            (new FastRoute($dispatcher))->attribute('handler'),
+            function ($request) {
+                echo $request->getAttribute('handler');
+            }
         ], $request);
 
-        $this->assertEquals('Hello oscarotero (35)', (string) $response->getBody());
+        $this->assertEquals('listUsers', (string) $response->getBody());
     }
 }


### PR DESCRIPTION
This removes all handler/controller resolving and invoking. By
separating discovery from execution, it is possible to apply routing
much earlier and send 404s and 405s as soon as possible.

This provides clearer separation of concerns and allows more complex
middleware configurations.

Refs #5 