### PR TITLE
Add ResponseFactoryInterface param to construct.

### DIFF
--- a/src/FastRoute.php
+++ b/src/FastRoute.php
@@ -29,11 +29,12 @@ class FastRoute implements MiddlewareInterface
     private $responseFactory;
 
     /**
-     * Set the Dispatcher instance.
+     * Set the Dispatcher instance and optionally the response factory to return the error responses.
      */
-    public function __construct(Dispatcher $router)
+    public function __construct(Dispatcher $router, ResponseFactoryInterface $responseFactory = null)
     {
         $this->router = $router;
+        $this->responseFactory = $responseFactory ?? Factory::getResponseFactory();
     }
 
     /**
@@ -64,13 +65,11 @@ class FastRoute implements MiddlewareInterface
         $route = $this->router->dispatch($request->getMethod(), $request->getUri()->getPath());
 
         if ($route[0] === Dispatcher::NOT_FOUND) {
-            $responseFactory = $this->responseFactory ?: Factory::getResponseFactory();
-            return $responseFactory->createResponse(404);
+            return $this->responseFactory->createResponse(404);
         }
 
         if ($route[0] === Dispatcher::METHOD_NOT_ALLOWED) {
-            $responseFactory = $this->responseFactory ?: Factory::getResponseFactory();
-            return $responseFactory->createResponse(405)->withHeader('Allow', implode(', ', $route[1]));
+            return $this->responseFactory->createResponse(405)->withHeader('Allow', implode(', ', $route[1]));
         }
 
         foreach ($route[2] as $name => $value) {


### PR DESCRIPTION
Like a `Dispatcher` instance, a `ResponseFactoryInterface` instance must be available for this middleware to run. It makes sense for it to be set during construction.

This also enables automatic dependency injecting (“autowiring”) such as available through [Auryn](https://github.com/rdlowrey/auryn), [PHP-DI](http://php-di.org/doc/autowiring.html), [Symfony](https://symfony.com/doc/current/service_container/autowiring.html), and (probably) many others.

Another perk is that `Factory::getResponseFactory` gets to run during construction now as well. If it is incapable of finding a factory it can throw there, rather than waiting for `FastRoute::process` to be called.

I have left the `FastRoute::responseFactory` method in case people want to change their response factory after the fact. But am tempted to remove it. There isn’t a separate method for changing the dispatcher after construction either.

What do you think?

I’d also appreciate some guidance on how you’d like this documented in the README in case you would consider merging 😃 