### PR TITLE
Add support for encoded path

### DIFF
--- a/src/FastRoute.php
+++ b/src/FastRoute.php
@@ -50,7 +50,7 @@ class FastRoute implements MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        $route = $this->router->dispatch($request->getMethod(), $request->getUri()->getPath());
+        $route = $this->router->dispatch($request->getMethod(), rawurldecode($request->getUri()->getPath()));
 
         if ($route[0] === Dispatcher::NOT_FOUND) {
             return $this->createResponse(404);


### PR DESCRIPTION
Decode url path before matching routes to work with any path with accent.

Example
- http://localhost:8080/hello/accentu%C3%A9

Which should decoded as:
- http://localhost:8080/hello/accentué

This is also done in Symfony:
https://github.com/symfony/symfony/blob/4.2/src/Symfony/Component/Routing/Matcher/UrlMatcher.php#L87
