### PR TITLE
feat: continueOnNotFound option

### DIFF
--- a/src/FastRoute.php
+++ b/src/FastRoute.php
@@ -19,6 +19,12 @@ class FastRoute implements MiddlewareInterface
     private $router;
 
     /**
+     * @var bool
+     */
+    private $continueOnNotFound = false;
+
+
+    /**
      * @var string Attribute name for handler reference
      */
     private $attribute = 'request-handler';
@@ -35,6 +41,16 @@ class FastRoute implements MiddlewareInterface
     {
         $this->router = $router;
         $this->responseFactory = $responseFactory ?: Factory::getResponseFactory();
+    }
+
+    /**
+     * Configure whether to continue with next handler if route is not found.
+     */
+    public function continueOnNotFound(bool $continueOnNotFound = true): self
+    {
+        $this->continueOnNotFound = $continueOnNotFound;
+
+        return $this;
     }
 
     /**
@@ -55,6 +71,10 @@ class FastRoute implements MiddlewareInterface
         $route = $this->router->dispatch($request->getMethod(), rawurldecode($request->getUri()->getPath()));
 
         if ($route[0] === Dispatcher::NOT_FOUND) {
+            if ($this->continueOnNotFound) {
+                return $handler->handle($request);
+            }
+
             return $this->responseFactory->createResponse(404);
         }
 

--- a/tests/FastRouteTest.php
+++ b/tests/FastRouteTest.php
@@ -26,6 +26,25 @@ class FastRouteTest extends TestCase
         $this->assertEquals(404, $response->getStatusCode());
     }
 
+    public function testFastRouteContinueOnNotFound()
+    {
+        $dispatcher = simpleDispatcher(function (\FastRoute\RouteCollector $r) {
+            $r->get('/users', 'listUsers');
+        });
+
+        $request = Factory::createServerRequest('GET', '/posts');
+
+        $response = Dispatcher::run([
+            (new FastRoute($dispatcher))->continueOnNotFound(),
+            function ($request) {
+                echo 'Hello from next handler';
+            },
+        ], $request);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('Hello from next handler', (string) $response->getBody());
+    }
+
     public function testFastRouteNotAllowed()
     {
         $dispatcher = simpleDispatcher(function (\FastRoute\RouteCollector $r) {


### PR DESCRIPTION
Hi,

What do you think about this? I have a use case where I need to have a New Router on top of an Old Router, so if the New Router does not find a route for the Request, it gives the opportunity to the Old Router to handle it and try to match a route for it.

To give a bit more context, in the Old Router I check whether the request-handler attribute is already set in which case I delegate to the next handler:
```php
if ($request->getAttribute('request-handler') !== null) {
    return $next->handle($request);
}
```

I think we should handle these situations where we might have "multiple request handlers finders" (routers).

I'm also thinking about whether It would be a good idea to have some sort of "404 not found" behaviour (set default 404 Response) for the request-handler component if the request-handler attribute was not set in any of the handlers.

Let me know what you think and if it's ok I can update the README.md and do the same for the Aura Router package.

---

P.D: Now I also have doubts about what should happen with the 405.